### PR TITLE
Update mlx dependency version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-mlx = "^0.0.10"
+mlx = "^0.2.0"
 gymnasium = {extras = ["classic-control"], version = "^0.29.1"}
 
 


### PR DESCRIPTION
The mlx library version dependency in the pyproject.toml has been updated from "^0.0.10" to "^0.2.0". This change implies that the project is now reliant on a more recent version of the mlx library.