### PR TITLE
Updated ppo with the right implementation

### DIFF
--- a/rlx/ppo/main.py
+++ b/rlx/ppo/main.py
@@ -145,10 +145,9 @@ if __name__ == "__main__":
         [make_env(args.env_id) for i in range(args.num_envs)],
     )
     assert isinstance(
-        envs.single_observation_space,
+        envs.single_action_space,
         gym.spaces.Discrete,
-        "Only discrete action spaces are supported",
-    )
+    ), "Only discrete action spaces are supported"
 
     actor = Actor(
         num_layers=2,

--- a/rlx/ppo/ppo.py
+++ b/rlx/ppo/ppo.py
@@ -32,8 +32,11 @@ class PPO:
         log_probs = mx.log(probs)
         return log_probs
 
-    def get_entropy(self, probs, log_probs):
-        entropy = -mx.sum(probs * log_probs)
+    def get_entropy(self, observations):
+        logits = self.actor(observations)
+        probs = nn.softmax(logits)
+        log_probs = nn.log_softmax(logits)
+        entropy = -mx.sum(probs * log_probs, axis=1)
         return entropy
 
     def get_approx_kl(self, observations, actions, old_log_probs):
@@ -53,7 +56,7 @@ class PPO:
         probs = self.get_prob(observations, actions)
         log_probs = mx.log(probs)
         ratios = mx.exp(log_probs - old_log_probs)
-        entropy = self.get_entropy(probs, log_probs)
+        entropy = self.get_entropy(observations)
         loss = mx.minimum(
             ratios * advantages,
             mx.clip(ratios, 1 - 0.2, 1 + 0.2) * advantages,


### PR DESCRIPTION
Hi @noahfarr, thank you for the work on this --- I was playing around with it a bit a few days ago and noticed that PPO wasn’t implemented quite right. This PR fixes that.

The main issue was with the entropy term in the PPO objective: the implementation was not computing the entropy of the full policy distribution, but instead using only the probability of the selected action. It changes the behavior of the exploration bonus quite a bit.

The original code effectively did:
```python
def get_prob(self, observations, actions):
    logits = self.actor(observations)
    probs = nn.softmax(logits)[
        mx.arange(actions.shape[0]),
        actions.astype(mx.int32),
    ]
    return probs  # shape: (batch,)

def get_entropy(self, probs, log_probs):
    entropy = -mx.sum(probs * log_probs)
    return entropy

# In the loss:
probs = self.get_prob(observations, actions)  # (batch,)
log_probs = mx.log(probs)
entropy = self.get_entropy(probs, log_probs)  # scalar
entropy_loss = entropy_coef * entropy.mean()  # .mean() on scalar
```

Here:

`probs` is only the probability of the chosen action for each sample in the batch and `get_entropy` then multiplies that by its own log-probability and sums over the whole batch, giving a single scalar. There is no consideration of the other actions in the action space, and no per-state notion of how spread out the policy is.

So instead of measuring "how uncertain the policy is over all possible actions for each state", it is ending up being a somewhat arbitrary batch-summed quantity that doesn't match the usual definition of policy entropy used in PPO.

This PR changes the entropy helper to operate on the full action distribution for each observation:

```python
def get_entropy(self, observations):
    """
    Compute entropy of the policy distribution.
    Entropy = -sum(p * log(p)) for each sample in the batch.

    Args:
        observations: Input observations (batch_size, obs_dim)

    Returns:
        entropy: Per-sample entropy (batch_size,)
    """
    logits = self.actor(observations)                 # (batch_size, num_actions)
    probs = nn.softmax(logits, axis=-1)              # probabilities over all actions
    log_probs = nn.log_softmax(logits, axis=-1)      # log-probabilities, numerically stable
    entropy = -mx.sum(probs * log_probs, axis=-1)    # sum over actions, keep batch dim
    return entropy                                   # (batch_size,)
```

And the actor loss now uses it like this:

```python
entropy = self.get_entropy(observations)             # (batch_size,)
entropy_loss = entropy_coef * entropy.mean()         # scalar
loss = -mx.mean(clipped_objective) - entropy_loss
```

This actually matches how entropy regularization is defined and used in the original PPO paper by Schulman et al. (Proximal Policy Optimization Algorithms) and in common reference implementations like OpenAI Baselines and CleanRL.
